### PR TITLE
Fix leaked fds

### DIFF
--- a/core/pycopia/OS/Linux/Input.py
+++ b/core/pycopia/OS/Linux/Input.py
@@ -271,7 +271,7 @@ class EventDevice(object):
                 else:
                     if name in self.name:
                         return
-        self.close()
+            self.close()
         raise IOError("Input device %r not found." % (name,))
 
     def open(self, filename):


### PR DESCRIPTION
I haven't seen to much activity here so I wasn't sure if this project is still actively developed, but I found a bug when it comes to searching for devices. This usually isn't a problem, but the project I'm using this code for is communicating with bluetooth devices so it's possible for them to disappear and I've been using the `find` method as a polling tool. It leaks an fd whenever it scans a device that doesn't match, which, with the way I'm using it, causes the max number of open file descriptors to get hit relatively quickly